### PR TITLE
Add character set collation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ The following table lists the configurable parameters and their default values.
 | `SqlMode`                         | May contain string with comma separated sql modes, for example `STRICT_ALL_TABLES`. Do not set it at config, if you want null value.                            | `null`  |
 | `DebugDelaySeconds`               | Delay for debug purposes, used in schema read and insert operations                                                                                             | `0`     |
 | `SkipColumnsRegexes`              | Map, where key - regex to select table, and value - array of column names, which values will be skipped. For example, `"supplycomposition": ["ModifiedUserId"]` | `{}`    |
+| `DatabaseCollation`               | Override destination database collation. If not set, source database collation is used.                                                                         | `null`  |
+| `DatabaseCharacterSet`            | Override destination database character set. If not set, source database character set is used.                                                                 | `null`  |
 | `CreateSchema`                    | If true, then create schema (tables, views, routines, triggers) on destination database.                                                                        | `true`  |
 | `ConnectionStrings.Src`           | _Required_ Connection string to source database                                                                                                                 | `null`  |
 | `ConnectionStrings.Dst`           | _Required_ Connection string to destination database                                                                                                            | `null`  |

--- a/integration-tests/init.sql
+++ b/integration-tests/init.sql
@@ -6,7 +6,7 @@ CREATE TABLE `table_without_pk`
 (
     `Created` timestamp     NOT NULL DEFAULT CURRENT_TIMESTAMP,
     `Message` varchar(1000)
-) ENGINE = InnoDB;
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB;
 
 
 DROP TABLE IF EXISTS table_with_composite_pk;
@@ -79,8 +79,8 @@ DELIMITER ;
 DELIMITER //
 CREATE PROCEDURE fill(OUT status CHAR)
 BEGIN
-    -- CALL fill_table_without_pk(@records);
-    -- CALL fill_table_with_composite_pk(@records);
+    CALL fill_table_without_pk(@records);
+    CALL fill_table_with_composite_pk(@records);
     SELECT 'INIT COMPLETE' AS status;
     CREATE USER 'ready'@'%' IDENTIFIED BY 'ready';
 END//

--- a/src/Dodo.DataMover/DataManipulation/DatabaseMapping/DatabaseMatadataDto.cs
+++ b/src/Dodo.DataMover/DataManipulation/DatabaseMapping/DatabaseMatadataDto.cs
@@ -1,0 +1,8 @@
+namespace Dodo.DataMover.DataManipulation.DatabaseMapping
+{
+    public class DatabaseMatadataDto
+    {
+        public string CharacterSet { get; set; }
+        public string Collation { get; set; }
+    }
+}

--- a/src/Dodo.DataMover/DataManipulation/SchemaCopier.cs
+++ b/src/Dodo.DataMover/DataManipulation/SchemaCopier.cs
@@ -98,16 +98,27 @@ namespace Dodo.DataMover.DataManipulation
             var cmd = connection.CreateCommand();
 
             cmd.CommandType = CommandType.Text;
+
+            var collation = "";
+            if (!string.IsNullOrEmpty(_dataMoverSettings.DatabaseCollation))
+            {
+                collation = $" COLLATE {_dataMoverSettings.DatabaseCollation}";
+            }
+
+            var characterSet = "";
+            if (!string.IsNullOrEmpty(_dataMoverSettings.DatabaseCharacterSet))
+            {
+                characterSet = $" CHARACTER SET {_dataMoverSettings.DatabaseCharacterSet}";
+            }
+
+            cmd.CommandText = "";
             if (_dataMoverSettings.DropDatabase)
             {
                 cmd.CommandText =
-                    $"DROP DATABASE IF EXISTS `{databaseName}`; CREATE DATABASE IF NOT EXISTS `{databaseName}`;";
-            }
-            else
-            {
-                cmd.CommandText = $"CREATE DATABASE IF NOT EXISTS `{databaseName}`;";
+                    $"DROP DATABASE IF EXISTS `{databaseName}`;";
             }
 
+            cmd.CommandText += $"CREATE DATABASE IF NOT EXISTS `{databaseName}` {characterSet} {collation};";
             cmd.CommandTimeout = _dataMoverSettings.SchemaReadCommandTimeoutSeconds;
 
             await cmd.ExecuteNonQueryAsync(token);

--- a/src/Dodo.DataMover/DataManipulation/SchemaCopier.cs
+++ b/src/Dodo.DataMover/DataManipulation/SchemaCopier.cs
@@ -88,6 +88,8 @@ namespace Dodo.DataMover.DataManipulation
 
         private async Task CreateDatabaseSchemaAsync(CancellationToken token)
         {
+            var databaseMetadata = await ReadDatabaseMetadataAsync(token);
+
             var dstConnectionStringBuilder = new MySqlConnectionStringBuilder(_dataMoverSettings.ConnectionStrings.Dst);
             var databaseName = dstConnectionStringBuilder.Database;
             dstConnectionStringBuilder.Database = null;
@@ -99,18 +101,6 @@ namespace Dodo.DataMover.DataManipulation
 
             cmd.CommandType = CommandType.Text;
 
-            var collation = "";
-            if (!string.IsNullOrEmpty(_dataMoverSettings.DatabaseCollation))
-            {
-                collation = $" COLLATE {_dataMoverSettings.DatabaseCollation}";
-            }
-
-            var characterSet = "";
-            if (!string.IsNullOrEmpty(_dataMoverSettings.DatabaseCharacterSet))
-            {
-                characterSet = $" CHARACTER SET {_dataMoverSettings.DatabaseCharacterSet}";
-            }
-
             cmd.CommandText = "";
             if (_dataMoverSettings.DropDatabase)
             {
@@ -118,7 +108,10 @@ namespace Dodo.DataMover.DataManipulation
                     $"DROP DATABASE IF EXISTS `{databaseName}`;";
             }
 
-            cmd.CommandText += $"CREATE DATABASE IF NOT EXISTS `{databaseName}` {characterSet} {collation};";
+            var collation = _dataMoverSettings.DatabaseCollation ?? databaseMetadata.Collation;
+            var characterSet = _dataMoverSettings.DatabaseCharacterSet ?? databaseMetadata.CharacterSet;
+
+            cmd.CommandText += $"CREATE DATABASE IF NOT EXISTS `{databaseName}` CHARACTER SET {characterSet} COLLATE {collation};";
             cmd.CommandTimeout = _dataMoverSettings.SchemaReadCommandTimeoutSeconds;
 
             await cmd.ExecuteNonQueryAsync(token);
@@ -195,6 +188,27 @@ namespace Dodo.DataMover.DataManipulation
                 _logger.LogDebug("{@EventType}", $"Delay for {_dataMoverSettings.DebugDelaySeconds} sec");
                 await Task.Delay(TimeSpan.FromSeconds(_dataMoverSettings.DebugDelaySeconds), token);
             }
+        }
+
+        private async Task<DatabaseMatadataDto> ReadDatabaseMetadataAsync(CancellationToken token)
+        {
+            var db = new DatabaseGateway(_dataMoverSettings.ConnectionStrings.Src,
+                _dataMoverSettings.SchemaReadCommandTimeoutSeconds, _policyFactory.SrcPolicy);
+
+            var dbName = new MySqlConnectionStringBuilder(_dataMoverSettings.ConnectionStrings.Src).Database;
+
+            var sql = @"select distinct DEFAULT_CHARACTER_SET_NAME as CharacterSet, DEFAULT_COLLATION_NAME as Collation
+from information_schema.SCHEMATA
+where SCHEMA_NAME = @databaseName;";
+
+            return (await db.ReadAsync(default(Unused), sql,
+                (_, collection) => collection.AddWithValue("databaseName", dbName),
+                (_, reader) => new DatabaseMatadataDto
+                {
+                    CharacterSet = reader.GetString("CharacterSet"),
+                    Collation = reader.GetString("Collation")
+                },
+                token)).Single();
         }
 
         private async Task<List<DatabaseObjectDto>> ReadMetadataAsync(CancellationToken token)

--- a/src/Dodo.DataMover/DataMoverSettings.cs
+++ b/src/Dodo.DataMover/DataMoverSettings.cs
@@ -143,6 +143,10 @@ namespace Dodo.DataMover
 
         public int RetryInitialDelaySeconds { get; set; } = 3;
         public int RetryCount { get; set; } = 5;
+
+        public string DatabaseCollation { get; set; } = null;
+
+        public string DatabaseCharacterSet { get; set; } = null;
     }
 
 

--- a/src/Dodo.DataMover/appsettings.local.template.json
+++ b/src/Dodo.DataMover/appsettings.local.template.json
@@ -24,6 +24,8 @@
     "SkipColumnsRegexes": {
       "supplycomposition": ["ModifiedUserId"]
     },
+    "DatabaseCollation":"utf8_general_ci",
+    "DatabaseCharacterSet":"utf8",
     "CreateSchema": "true",
     "ConnectionStrings": {
       "Src": "Data Source=127.0.0.1; Port=33060; Initial Catalog=test_db; Character Set=utf8; User Id=root; Password=mover; convertzerodatetime=true; Allow User Variables=True; Pooling=true;  SSL Mode=None; ConnectionLifeTime=180; Connect Timeout=5",


### PR DESCRIPTION
Fix #23 

Read default collation and character set from source database, use it when create database at destination server.
Add ability to override destination database collation and character set through config.