### PR TITLE
#8717560 update .net version

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Pull request
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
 
       - name: Checkout code

--- a/.github/workflows/on-push-to-master.yml
+++ b/.github/workflows/on-push-to-master.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Push to master
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
 
       - name: Checkout code

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build and test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
 
       - name: Checkout code

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
 
       - name: Checkout code

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+    "sdk": {
+        "version": "7.0.102",
+        "rollForward": "latestFeature"
+    }
+}

--- a/linux.Dockerfile
+++ b/linux.Dockerfile
@@ -1,6 +1,6 @@
 FROM dodopizza/mysql-data-mover-platforms as builder
 
-FROM mcr.microsoft.com/dotnet/core/runtime:3.1
+FROM mcr.microsoft.com/dotnet/runtime:7.0.2-bullseye-slim
 WORKDIR /app
 COPY --from=builder ./output/linux-x64/ .
 CMD [ "/app/Dodo.DataMover" ]

--- a/platforms.Dockerfile
+++ b/platforms.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 as builder
+FROM mcr.microsoft.com/dotnet/sdk:7.0.102-bullseye-slim as builder
 COPY src ./src
 COPY mysql-data-mover.sln .
 ENV SOLUTION_NAME "./mysql-data-mover.sln"
@@ -9,4 +9,3 @@ RUN dotnet publish -r linux-x64 /p:PublishSingleFile=true -c Release --output ./
     dotnet publish -r linux-musl-x64 /p:PublishSingleFile=true -c Release --output ./output/linux-musl-x64 ${SOLUTION_NAME} && \
     dotnet publish -r win-x64 /p:PublishSingleFile=true -c Release --output ./output/win-x64 ${SOLUTION_NAME} && \
     dotnet publish -r osx-x64 /p:PublishSingleFile=true -c Release --output ./output/osx-x64 ${SOLUTION_NAME}
-# kick the build 2020-08-06 15:32

--- a/src/Dodo.DataMover.Tests/Dodo.DataMover.Tests.csproj
+++ b/src/Dodo.DataMover.Tests/Dodo.DataMover.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <IsPublishable>false</IsPublishable>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Dodo.DataMover/Dodo.DataMover.csproj
+++ b/src/Dodo.DataMover/Dodo.DataMover.csproj
@@ -2,8 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-        <LangVersion>8</LangVersion>
+        <TargetFramework>net7.0</TargetFramework>
         <VersionPrefix>0.1</VersionPrefix>
         <InvariantGlobalization>true</InvariantGlobalization>
     </PropertyGroup>

--- a/verification.Dockerfile
+++ b/verification.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 as builder
+FROM mcr.microsoft.com/dotnet/sdk:7.0.102-bullseye-slim as builder
 COPY src ./src
 COPY mysql-data-mover.sln .
 ENV SOLUTION_NAME "./mysql-data-mover.sln"


### PR DESCRIPTION
Use .Net 7.0 instead of 3.1 (now we can develop on Mac M1)
Update deprecated GitHub Actions runner version.