### PR TITLE
#20818634 do not copy stored generated columns

### DIFF
--- a/src/Dodo.DataMover/DataManipulation/SourceSchemaReader.cs
+++ b/src/Dodo.DataMover/DataManipulation/SourceSchemaReader.cs
@@ -249,7 +249,7 @@ LEFT JOIN information_schema.key_column_usage k
 ON c.TABLE_NAME = k.TABLE_NAME and c.TABLE_SCHEMA = k.TABLE_SCHEMA and c.COLUMN_NAME = k.COLUMN_NAME and k.CONSTRAINT_NAME='PRIMARY'
 LEFT JOIN information_schema.table_constraints t
 ON k.TABLE_NAME = t.TABLE_NAME and k.TABLE_SCHEMA = t.TABLE_SCHEMA and t.CONSTRAINT_NAME = k.CONSTRAINT_NAME and t.CONSTRAINT_TYPE='PRIMARY KEY'
-WHERE  c.TABLE_SCHEMA='menu' and c.EXTRA not in ('VIRTUAL GENERATED', 'STORED GENERATED');",
+WHERE  c.TABLE_SCHEMA=@databaseName and c.EXTRA not in ('VIRTUAL GENERATED', 'STORED GENERATED');",
                 (dbName, parameters) => parameters.AddWithValue("databaseName", dbName),
                 (_, reader) => new ColumnDto
                 {

--- a/src/Dodo.DataMover/DataManipulation/SourceSchemaReader.cs
+++ b/src/Dodo.DataMover/DataManipulation/SourceSchemaReader.cs
@@ -249,7 +249,7 @@ LEFT JOIN information_schema.key_column_usage k
 ON c.TABLE_NAME = k.TABLE_NAME and c.TABLE_SCHEMA = k.TABLE_SCHEMA and c.COLUMN_NAME = k.COLUMN_NAME and k.CONSTRAINT_NAME='PRIMARY'
 LEFT JOIN information_schema.table_constraints t
 ON k.TABLE_NAME = t.TABLE_NAME and k.TABLE_SCHEMA = t.TABLE_SCHEMA and t.CONSTRAINT_NAME = k.CONSTRAINT_NAME and t.CONSTRAINT_TYPE='PRIMARY KEY'
-WHERE  c.TABLE_SCHEMA=@databaseName AND c.EXTRA != 'VIRTUAL GENERATED'",
+WHERE  c.TABLE_SCHEMA='menu' and c.EXTRA not in ('VIRTUAL GENERATED', 'STORED GENERATED');",
                 (dbName, parameters) => parameters.AddWithValue("databaseName", dbName),
                 (_, reader) => new ColumnDto
                 {


### PR DESCRIPTION
Fix copy error `The value specified for generated column 'id' in table 'countries' is not allowed.` for tables with STORED GENERATED columns:

```
CREATE TABLE `countries` (
  `id` binary(16) GENERATED ALWAYS AS (unhex(json_unquote(json_extract(`data`,_utf8mb4'$.uuId')))) STORED NOT NULL,
  `country_id` int(11) GENERATED ALWAYS AS (json_extract(`data`,_utf8mb4'$.id')) VIRTUAL NOT NULL,
  `business_id` binary(16) NOT NULL,
  `received_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
  `data` json NOT NULL,
  PRIMARY KEY (`id`),
  KEY `business_id` (`business_id`,`country_id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
```