### PR TITLE
fix warning NETSDK1194

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV SOLUTION_NAME "./mysql-data-mover.sln"
 RUN dotnet restore ${SOLUTION_NAME}
 RUN dotnet build --no-restore --configuration Release ${SOLUTION_NAME}
 RUN dotnet test --no-restore --configuration Release ${SOLUTION_NAME}
-RUN dotnet publish --no-restore --configuration Release -o output ${SOLUTION_NAME}
+RUN dotnet publish --no-restore --configuration Release --property:PublishDir=/output ${SOLUTION_NAME}
 
 FROM mcr.microsoft.com/dotnet/runtime:8.0-jammy-chiseled
 WORKDIR /app


### PR DESCRIPTION
Правка workflow:
```
#17 [linux/arm64 builder 4/7] RUN dotnet restore ./mysql-data-mover.sln
#17 ...

#20 [linux/amd64 builder 7/7] RUN dotnet publish --no-restore --configuration Release -o output ./mysql-data-mover.sln
#20 0.382 MSBuild version 17.8.3+195e7f5a3 for .NET
#20 0.863 /usr/share/dotnet/sdk/8.0.100/Current/SolutionFile/ImportAfter/Microsoft.NET.Sdk.Solution.targets(36,5): warning NETSDK1194: The "--output" option isn't supported when building a solution. Specifying a solution-level output path results in all projects copying outputs to the same directory, which can lead to inconsistent builds. [/mysql-data-mover.sln]
#20 1.753   Dodo.DataMover -> /src/Dodo.DataMover/bin/Release/net8.0/Dodo.DataMover.dll
#20 1.888   Dodo.DataMover -> /output/
#20 DONE 2.0s
```

https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid#single-project-multiple-targetframeworks

нужно или юзать --property:OutputPath=DESIRED_PATH (чтобы было как раньше)

или 

> The general recommendation is to perform the action that you previously took without the --output/-o option, and then move the output to the desired location after the command has completed.