### PR TITLE
fix warning as error NU1900

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,23 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0-jammy as builder
+
+# Must be linux/amd64 or linux/arm64
+ARG TARGETARCH
+
 COPY src ./src
 COPY mysql-data-mover.sln .
 
 ENV SOLUTION_NAME "./mysql-data-mover.sln"
 
-RUN dotnet restore ${SOLUTION_NAME}
-RUN dotnet build --no-restore --configuration Release ${SOLUTION_NAME}
+RUN dotnet restore ${SOLUTION_NAME} --arch ${TARGETARCH} --packages /packages/${TARGETARCH}
+RUN dotnet build --no-restore --source /packages/${TARGETARCH} --configuration Release ${SOLUTION_NAME}
 RUN dotnet test --no-restore --configuration Release ${SOLUTION_NAME}
-RUN dotnet publish --no-restore --configuration Release --property:PublishDir=/output ${SOLUTION_NAME}
+RUN dotnet publish --no-restore --source /packages/${TARGETARCH} --configuration Release --property:PublishDir=/output/${TARGETARCH} ${SOLUTION_NAME}
 
 FROM mcr.microsoft.com/dotnet/runtime:8.0-jammy-chiseled
+
+# Must be linux/amd64 or linux/arm64
+ARG TARGETARCH
+
 WORKDIR /app
-COPY --from=builder ./output/ .
+COPY --from=builder ./output/${TARGETARCH} .
 ENTRYPOINT ["dotnet", "Dodo.DataMover.dll"]


### PR DESCRIPTION
Fix:
```
 > [linux/arm64 builder 4/7] RUN dotnet restore ./mysql-data-mover.sln:
23.95   Determining projects to restore...
pertyInfo'. [/mysql-data-mover.sln]
90.57 /src/Dodo.DataMover.Tests/Dodo.DataMover.Tests.csproj : error NU1900: Warning As Error: Error occurred while getting package vulnerability data: Unable to cast object of type 'System.Net.Http.HttpRequestMessage' to type 'System.Text.Json.Serialization.Metadata.JsonPropertyInfo'. [/mysql-data-mover.sln]
92.12   Failed to restore /src/Dodo.DataMover.Tests/Dodo.DataMover.Tests.csproj (in 1.02 min).
92.12   Failed to restore /src/Dodo.DataMover/Dodo.DataMover.csproj (in 1.02 min).
```