### PR TITLE
disable warning for NU1900

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,6 +3,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <NoWarn>NU1900</NoWarn> <!-- Fix linux/arm64 bug? error NU1900: Warning As Error: Error occurred while getting package vulnerability data: Unable to cast object of type 'System.Net.Http.HttpRequestMessage' to type 'System.Text.Json.Serialization.Metadata.JsonPropertyInfo' -->
 <!--        <ImplicitUsings>enable</ImplicitUsings>-->
 <!--        <Nullable>enable</Nullable>-->
     </PropertyGroup>


### PR DESCRIPTION
Fix(?) for linux/arm64:
```
#17 [linux/arm64 builder 4/7] RUN dotnet restore ./mysql-data-mover.sln --arch arm64 --packages /packages/arm64
#17 102.9 /src/Dodo.DataMover.Tests/Dodo.DataMover.Tests.csproj : error NU1900: Warning As Error: Error occurred while getting package vulnerability data: Unable to cast object of type 'System.Net.Http.HttpRequestMessage' to type 'System.Text.Json.Serialization.Metadata.JsonPropertyInfo'. [/mysql-data-mover.sln]
#17 102.9 /src/Dodo.DataMover/Dodo.DataMover.csproj : error NU1900: Warning As Error: Error occurred while getting package vulnerability data: Unable to cast object of type 'System.Net.Http.HttpRequestMessage' to type 'System.Text.Json.Serialization.Metadata.JsonPropertyInfo'. [/mysql-data-mover.sln]
#17 106.1   Failed to restore /src/Dodo.DataMover.Tests/Dodo.DataMover.Tests.csproj (in 1.23 min).
#17 106.1   Failed to restore /src/Dodo.DataMover/Dodo.DataMover.csproj (in 1.23 min).
#17 ERROR: process "/bin/sh -c dotnet restore ${SOLUTION_NAME} --arch ${TARGETARCH} --packages /packages/${TARGETARCH}" did not complete successfully: exit code: 1
```

https://learn.microsoft.com/ru-ru/nuget/reference/errors-and-warnings/nu1900

https://learn.microsoft.com/en-us/nuget/concepts/auditing-packages#warning-codes