### PR TITLE
fix release workflow, failed dotnet build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0-jammy as builder
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0-jammy as builder
 
 # Must be linux/amd64 or linux/arm64
 ARG TARGETARCH
@@ -8,12 +8,12 @@ COPY mysql-data-mover.sln .
 
 ENV SOLUTION_NAME "./mysql-data-mover.sln"
 
-RUN dotnet restore ${SOLUTION_NAME} --arch ${TARGETARCH} --packages /packages/${TARGETARCH}
-RUN dotnet build --no-restore --source /packages/${TARGETARCH} --configuration Release ${SOLUTION_NAME}
+RUN dotnet restore ${SOLUTION_NAME}
+RUN dotnet build --no-restore --configuration Release ${SOLUTION_NAME}
 RUN dotnet test --no-restore --configuration Release ${SOLUTION_NAME}
-RUN dotnet publish --no-restore --source /packages/${TARGETARCH} --configuration Release --property:PublishDir=/output/${TARGETARCH} ${SOLUTION_NAME}
+RUN dotnet publish --no-restore --configuration Release --property:PublishDir=/output/${TARGETARCH} ${SOLUTION_NAME}
 
-FROM mcr.microsoft.com/dotnet/runtime:8.0-jammy-chiseled
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/runtime:8.0-jammy-chiseled
 
 # Must be linux/amd64 or linux/arm64
 ARG TARGETARCH


### PR DESCRIPTION
Fix:
```
------
 > [linux/arm64 builder 5/7] RUN dotnet build --no-restore --source /packages/arm64 --configuration Release ./mysql-data-mover.sln:
54.47 /usr/share/dotnet/sdk/8.0.100/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.GenerateAssemblyInfo.targets(182,5): error MSB[401](https://github.com/dodopizza/mysql-data-mover/actions/runs/7297429802/job/19886651558#step:7:406)8: System.NullReferenceException: Object reference not set to an instance of an object. [/src/Dodo.DataMover.Tests/Dodo.DataMover.Tests.csproj]
54.47 /usr/share/dotnet/sdk/8.0.100/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.GenerateAssemblyInfo.targets(182,5): error MSB4018:    at InvokeStub_WriteLinesToFile.set_File(Object, Object, IntPtr*) [/src/Dodo.DataMover.Tests/Dodo.DataMover.Tests.csproj]
54.47 /usr/share/dotnet/sdk/8.0.100/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.GenerateAssemblyInfo.targets(182,5): error MSB4018:    at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr) [/src/Dodo.DataMover.Tests/Dodo.DataMover.Tests.csproj]
54.47 /usr/share/dotnet/sdk/8.0.100/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.GenerateAssemblyInfo.targets(182,58): error MSB[402](https://github.com/dodopizza/mysql-data-mover/actions/runs/7297429802/job/19886651558#step:7:407)6: The "File=$(GeneratedAssemblyInfoInputsCacheFile)" parameter for the "WriteLinesToFile" task is invalid. [/src/Dodo.DataMover.Tests/Dodo.DataMover.Tests.csproj]
54.47 /usr/share/dotnet/sdk/8.0.100/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.GenerateAssemblyInfo.targets(182,5): error MSB[406](https://github.com/dodopizza/mysql-data-mover/actions/runs/7297429802/job/19886651558#step:7:411)3: The "WriteLinesToFile" task could not be initialized with its input parameters.  [/src/Dodo.DataMover.Tests/Dodo.DataMover.Tests.csproj]
54.47 MSBUILD : error MSB4166: Child node "2" exited prematurely. Shutting down. Diagnostic information may be found in files in "/tmp/MSBuildTemproot/" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.
54.47     0 Warning(s)
54.47     4 Error(s)
54.47 
54.47 Time Elapsed 00:00:48.63
------
Dockerfile:12
--------------------
  10 |     
  11 |     RUN dotnet restore ${SOLUTION_NAME} --arch ${TARGETARCH} --packages /packages/${TARGETARCH}
  12 | >>> RUN dotnet build --no-restore --source /packages/${TARGETARCH} --configuration Release ${SOLUTION_NAME}
  13 |     RUN dotnet test --no-restore --configuration Release ${SOLUTION_NAME}
  14 |     RUN dotnet publish --no-restore --source /packages/${TARGETARCH} --configuration Release --property:PublishDir=/output/${TARGETARCH} ${SOLUTION_NAME}
--------------------
ERROR: failed to solve: process "/bin/sh -c dotnet build --no-restore --source /packages/${TARGETARCH} --configuration Release ${SOLUTION_NAME}" did not complete successfully: exit code: 1
Error: buildx failed with: ERROR: failed to solve: process "/bin/sh -c dotnet build --no-restore --source /packages/${TARGETARCH} --configuration Release ${SOLUTION_NAME}" did not complete successfully: exit code: 1
```

Also, fix M1 local build:
```
 docker buildx build --platform linux/amd64,linux/arm64 -t datamover --load .
 ```